### PR TITLE
Replace hashValues call with Object.hash

### DIFF
--- a/lib/src/signature_control.dart
+++ b/lib/src/signature_control.dart
@@ -56,7 +56,7 @@ class OffsetPoint extends Offset {
   }
 
   @override
-  int get hashCode => hashValues(super.hashCode, timestamp);
+  int get hashCode => Object.hash(super.hashCode, timestamp);
 }
 
 class CubicLine extends Offset {


### PR DESCRIPTION
Probably deprecated function in dart:ui Offset class.

Fixed by replacing hashValues call with Object.hash call. It's now identical to hand_signature libs implementation.

see: https://github.com/RomanBase/hand_signature/blob/32790cb21d42847dd6829f940e50b3cf6adb8d49/lib/src/signature_control.dart#L101